### PR TITLE
Moved signing process to a keystore.properties file instead of manually signing it

### DIFF
--- a/readyConfigExample.yml
+++ b/readyConfigExample.yml
@@ -72,12 +72,11 @@
           storepass: <password for jks file>
           keystoreAlias: <alias name of jks>
 
-        tasks:
-          tasks:
-            - task: android_create_local_properties #Create a local.properties file and writes the path of the android sdk in it
+    tasks:
+    - task: android_create_local_properties #Create a local.properties file and writes the path of the android sdk in it
 
-            - task: android_create_apk_file #Create apk file from project
+    - task: android_create_apk_file #Create apk file from project
 
-            - task: android_sign_app #Sign the apk file using the jks file specified
+    - task: android_sign_app #Sign the apk file using the jks file specified
 
-            - task: android_upload_hockeyapp #Upload the apk file to hockeyApp using the hockeyApp token specified
+    - task: android_upload_hockeyapp #Upload the apk file to hockeyApp using the hockeyApp token specified

--- a/readyConfigExample.yml
+++ b/readyConfigExample.yml
@@ -58,19 +58,19 @@
 
   - name: build-an-android-app
     parameters:
-          gitPath: <git url>
-          gitBranch: <branch that you want to clone from>
-          scheme: <target name>
-          hockappToken: <token>
-          hockeyappReleaseTags: <tags for release users or groups>
-          hockeyappReleaseNotes: New app build available
-          gitCommitMessage: Bumped the build number using Real CI
-          gitCommitFileList:
-          - <list of updated files to commit back to the repo>
-          androidSdkPath: <path to android sdk on local machine>
-          javaKeystorePath: <path to jks file>
-          storepass: <password for jks file>
-          keystoreAlias: <alias name of jks>
+      gitPath: <git url>
+      gitBranch: <branch that you want to clone from>
+      scheme: <target name>
+      hockappToken: <token>
+      hockeyappReleaseTags: <tags for release users or groups>
+      hockeyappReleaseNotes: New app build available
+      gitCommitMessage: Bumped the build number using Real CI
+      gitCommitFileList:
+      - <list of updated files to commit back to the repo>
+      androidSdkPath: <path to android sdk on local machine>
+      javaKeystorePath: <path to jks file>
+      storepass: <password for jks file>
+      keystoreAlias: <alias name of jks>
 
     tasks:
     - task: android_create_local_properties #Create a local.properties file and writes the path of the android sdk in it

--- a/src/main/java/com/squarepolka/readyci/tasks/app/android/AndroidCopyKeystoreProperties.java
+++ b/src/main/java/com/squarepolka/readyci/tasks/app/android/AndroidCopyKeystoreProperties.java
@@ -1,0 +1,30 @@
+package com.squarepolka.readyci.tasks.app.android;
+
+import com.squarepolka.readyci.taskrunner.BuildEnvironment;
+import com.squarepolka.readyci.tasks.Task;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class AndroidCopyKeystoreProperties extends Task {
+
+    public static final String TASK_COPY_KEYSTORE_PROPERTIES = "android_copy_keystore_properties";
+    public static final String BUILD_PROP_KEYSTORE_PROPERTIES_PATH = "keystorePropertiesPath";
+
+    @Override
+    public String taskIdentifier() {
+        return TASK_COPY_KEYSTORE_PROPERTIES;
+    }
+
+    @Override
+    public void performTask(BuildEnvironment buildEnvironment) throws Exception {
+        String keystorePropertiesPath = buildEnvironment.getProperty(BUILD_PROP_KEYSTORE_PROPERTIES_PATH);
+        String projectAppFolder = String.format("%s/app", buildEnvironment.projectPath);
+
+        executeCommand(new String[] {
+                "cp",
+                keystorePropertiesPath,
+                buildEnvironment.projectPath
+        }, buildEnvironment.projectPath);
+    }
+}


### PR DESCRIPTION
Removed duplicate 'tasks:' that will cause an error for the yml file.